### PR TITLE
fix(layout): fixing a bug that caused layout to wig out on ios

### DIFF
--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -59,8 +59,8 @@ export default Vue.extend({
     float: left;
 }
 .clicked {
-    width: 29px;
-    height: 29px;
-    border: 0.5px solid #8c8c8c;
+    width: 28px;
+    height: 28px;
+    border: 1px solid #8c8c8c;
 }
 </style>


### PR DESCRIPTION
I don't believe this altered the look of the layout, still functions on chrome and brave, tested on ios and I no longer run into the layout bug. Give it a quick look over yourself. I think the .5 caused it to go over the allowed container limit.

The smallest border size is actually 1px so .5 is rounded up