### PR TITLE
feat(saving): now saves game state through sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Attempting to create a copy of the original [Microsoft Minesweeper](https://en.wikipedia.org/wiki/Microsoft_Minesweeper) with Vue and TypeScript
 
-Site beta at https://minesweeper-app.netlify.com/
+Site beta at [https://minesweeper-app.netlify.com/](https://minesweeper-app.netlify.com/)

--- a/src/components/Grid.vue
+++ b/src/components/Grid.vue
@@ -18,11 +18,21 @@ interface Wasd {
 
 export default Vue.extend({
     name: 'Grid',
+    data() {
+        return {
+            saved_grid: localStorage.getItem('saved_grid'),
+            saved_zero_groups: localStorage.getItem('saved_zero_groups'),
+        }
+    },
     components: {
         Row,
     },
     created() {
-        this.$store.commit('setupGame')
+        if (this.saved_grid && this.saved_zero_groups) {
+            this.$store.commit('setupGame', { saved_grid: this.saved_grid, saved_zero_groups: this.saved_zero_groups })
+        } else {
+            this.$store.commit('setupGame')
+        }
     },
     computed: {
         gridStyles(): { width: string; height: string } {

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -26,12 +26,13 @@ export default Vue.extend({
         },
     },
     computed: {
-        ...mapGetters(['getGrid']),
+        ...mapGetters(['getGrid', 'getTileInfo']),
         tile_info(): Tile {
-            return this.$store.getters.getTileInfo(this.tile_id)
+            return this.getTileInfo(this.tile_id)
         },
+        // probably should use getTileStatus here?
         tile_status(): string {
-            return this.$store.getters.getTileInfo(this.tile_id).status
+            return this.getTileInfo(this.tile_id).status
         },
         clicked(): boolean {
             return this.tile_info.status === 'clicked'

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -14,6 +14,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
 import { Tile } from '@/types'
 
 export default Vue.extend({
@@ -25,8 +26,12 @@ export default Vue.extend({
         },
     },
     computed: {
+        ...mapGetters(['getGrid']),
         tile_info(): Tile {
             return this.$store.getters.getTileInfo(this.tile_id)
+        },
+        tile_status(): string {
+            return this.$store.getters.getTileInfo(this.tile_id).status
         },
         clicked(): boolean {
             return this.tile_info.status === 'clicked'
@@ -41,6 +46,11 @@ export default Vue.extend({
                 'background-color': this.tile_info.background_colour ? this.tile_info.background_colour : '#bdbdbd',
             }
             return wasd
+        },
+    },
+    watch: {
+        tile_status() {
+            localStorage.setItem('saved_grid', JSON.stringify(this.getGrid()))
         },
     },
     methods: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -33,10 +33,16 @@ export default new Vuex.Store({
         },
     },
     mutations: {
-        setupGame(state) {
+        setupGame(state, payload = undefined) {
             const { grid, zero_groups } = createGrid(state.game.x_length, state.game.y_length, state.game.mines)
-            state.grid = grid
-            state.zero_groups = zero_groups
+            if (payload) {
+                state.grid = JSON.parse(payload.saved_grid)
+                state.zero_groups = JSON.parse(payload.saved_zero_groups)
+            } else {
+                state.grid = grid
+                state.zero_groups = zero_groups
+            }
+            localStorage.setItem('saved_zero_groups', JSON.stringify(state.zero_groups))
         },
         setTileStatus(state, { tile_id, status }) {
             for (const tile of state.grid) {
@@ -79,6 +85,7 @@ export default new Vuex.Store({
                     tile.status = 'clicked'
                 }
             }
+            localStorage.clear()
         },
         wipeGrid(state) {
             state.game.status = 'playing'
@@ -86,6 +93,7 @@ export default new Vuex.Store({
                 tile.status = 'unclicked'
                 tile.value = ''
             }
+            localStorage.clear()
         },
     },
     actions: {
@@ -96,6 +104,7 @@ export default new Vuex.Store({
                         if (state.click_type.type === 'normal') {
                             if (tile.status === 'flagged' || tile.status === 'uncertain') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'unclicked' })
+                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             } else if (tile.status === 'unclicked') {
                                 if (tile.mine) {
                                     commit('setTileStatus', { tile_id: tile.id, status: 'clicked' })
@@ -105,16 +114,20 @@ export default new Vuex.Store({
                                     if (zero_group) {
                                         zero_group.zero_tile_ids.forEach((id: number) => commit('setTileStatus', { tile_id: id, status: 'clicked' }))
                                         zero_group.surrounding_tile_ids.forEach((id: number) => commit('setTileStatus', { tile_id: id, status: 'clicked' }))
+                                        localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                                     }
                                 } else {
                                     commit('setTileStatus', { tile_id: tile.id, status: 'clicked' })
+                                    localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                                 }
                             }
                         } else if (state.click_type.type === 'flag') {
                             if (tile.status === 'flagged') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'unclicked' })
+                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             } else if (tile.status !== 'clicked') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'flagged' })
+                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             }
                         }
                     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -104,7 +104,6 @@ export default new Vuex.Store({
                         if (state.click_type.type === 'normal') {
                             if (tile.status === 'flagged' || tile.status === 'uncertain') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'unclicked' })
-                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             } else if (tile.status === 'unclicked') {
                                 if (tile.mine) {
                                     commit('setTileStatus', { tile_id: tile.id, status: 'clicked' })
@@ -114,20 +113,16 @@ export default new Vuex.Store({
                                     if (zero_group) {
                                         zero_group.zero_tile_ids.forEach((id: number) => commit('setTileStatus', { tile_id: id, status: 'clicked' }))
                                         zero_group.surrounding_tile_ids.forEach((id: number) => commit('setTileStatus', { tile_id: id, status: 'clicked' }))
-                                        localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                                     }
                                 } else {
                                     commit('setTileStatus', { tile_id: tile.id, status: 'clicked' })
-                                    localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                                 }
                             }
                         } else if (state.click_type.type === 'flag') {
                             if (tile.status === 'flagged') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'unclicked' })
-                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             } else if (tile.status !== 'clicked') {
                                 commit('setTileStatus', { tile_id: tile.id, status: 'flagged' })
-                                localStorage.setItem('saved_grid', JSON.stringify(state.grid))
                             }
                         }
                     }


### PR DESCRIPTION
Merry Christmas lads

Using localStorage to save game state, saving it when there is a change to the tiles status. It's a little bit inefficient when a zero group is updated as it will store the grid multiple times at once. But it does save the state through sessions. clearing when necessary.

Will close issue #12